### PR TITLE
Revert to buildToolsVersion 23.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Build tools requirement 23.0.2 didn't work with RN 18. Changed it back to 23.0.1.
